### PR TITLE
Grid editor fixes

### DIFF
--- a/src/robotide/contrib/testrunner/testrunnerplugin.py
+++ b/src/robotide/contrib/testrunner/testrunnerplugin.py
@@ -216,12 +216,13 @@ class TestRunnerPlugin(Plugin):
         self.unsubscribe_all()
         self.unregister_actions()
 
-    def OnClose(self, evt):
+    def OnClose(self, event):
         """Shut down the running services and processes"""
         self._test_runner.kill_process()
         if self._process_timer:
             self._process_timer.Stop()
         self._test_runner.shutdown_server()
+        event.Skip()
 
     def OnAutoSaveCheckbox(self, evt):
         """Called when the user clicks on the "Auto Save" checkbox"""

--- a/src/robotide/editor/contentassist.py
+++ b/src/robotide/editor/contentassist.py
@@ -51,9 +51,9 @@ class _ContentAssistTextCtrlBase(object):
         keycode, control_down = event.GetKeyCode(), event.CmdDown()
         # print("DEBUG:  before processing" + str(keycode) + " + " +  str(control_down))
         # Ctrl-Space handling needed for dialogs # DEBUG add Ctrl-m
-        if (control_down or event.AltDown()) and keycode in (wx.WXK_SPACE, ord('m')):
-            self.show_content_assist()
-            return
+        # if (control_down or event.AltDown()) and keycode in (wx.WXK_SPACE, ord('m')):
+        #     self.show_content_assist()
+        #     return
         if keycode in [wx.WXK_UP, wx.WXK_DOWN, wx.WXK_PAGEUP, wx.WXK_PAGEDOWN]\
                 and self._popup.is_shown():
             self._popup.select_and_scroll(keycode)

--- a/src/robotide/editor/contentassist.py
+++ b/src/robotide/editor/contentassist.py
@@ -99,9 +99,9 @@ class _ContentAssistTextCtrlBase(object):
             event.Skip()
             return
         if self.gherkin_prefix:
-            value = self.gherkin_prefix + self._popup.get_value() or ""
+            value = self.gherkin_prefix + self._popup.get_value() or self.GetValue()
         else:
-            value =self._popup.get_value() or ""
+            value = self._popup.get_value() or self.GetValue()
         if set_value and value:
             self.SetValue(value)
             self.SetInsertionPoint(len(value))  # DEBUG was self.Value
@@ -386,6 +386,9 @@ class ContentAssistPopup(object):
         self._selection = selection
         self._list.Select(self._selection)
         self._list.EnsureVisible(self._selection)
+        value = self.get_value()
+        if value:
+            self._parent.SetValue(value)
 
     def hide(self):
         self._selection = -1

--- a/src/robotide/editor/contentassist.py
+++ b/src/robotide/editor/contentassist.py
@@ -51,21 +51,17 @@ class _ContentAssistTextCtrlBase(object):
         keycode, control_down = event.GetKeyCode(), event.CmdDown()
         # print("DEBUG:  before processing" + str(keycode) + " + " +  str(control_down))
         # Ctrl-Space handling needed for dialogs # DEBUG add Ctrl-m
-        # if (control_down or event.AltDown()) and keycode in (wx.WXK_SPACE, ord('m')):
-        #     self.show_content_assist()
-        #     return
-        if keycode in [wx.WXK_UP, wx.WXK_DOWN, wx.WXK_PAGEUP, wx.WXK_PAGEDOWN]\
+        if (control_down or event.AltDown()) and keycode in (wx.WXK_SPACE, ord('m')):
+            self.show_content_assist()
+        elif keycode in [wx.WXK_UP, wx.WXK_DOWN, wx.WXK_PAGEUP, wx.WXK_PAGEDOWN]\
                 and self._popup.is_shown():
             self._popup.select_and_scroll(keycode)
-            return
         elif keycode == wx.WXK_RETURN and self._popup.is_shown():
             self.OnFocusLost(event)
-            return
         elif keycode == wx.WXK_TAB:
             self.OnFocusLost(event, False)
         elif keycode == wx.WXK_ESCAPE and self._popup.is_shown():
             self._popup.hide()
-            return
         elif self._popup.is_shown() and keycode < 256:
             wx.CallAfter(self._populate_content_assist)
             event.Skip()

--- a/src/robotide/editor/contentassist.py
+++ b/src/robotide/editor/contentassist.py
@@ -49,8 +49,7 @@ class _ContentAssistTextCtrlBase(object):
     def OnChar(self, event):
         # TODO: This might benefit from some cleanup
         keycode, control_down = event.GetKeyCode(), event.CmdDown()
-        event.Skip()  # DEBUG do it as soon we do not need it
-        # print("DEBUG: Onchar before processing")
+        # print("DEBUG:  before processing" + str(keycode) + " + " +  str(control_down))
         # Ctrl-Space handling needed for dialogs # DEBUG add Ctrl-m
         if (control_down or event.AltDown()) and keycode in (wx.WXK_SPACE, ord('m')):
             self.show_content_assist()
@@ -68,13 +67,14 @@ class _ContentAssistTextCtrlBase(object):
             self._popup.hide()
             return
         elif self._popup.is_shown() and keycode < 256:
-            self._populate_content_assist(event)
+            wx.CallAfter(self._populate_content_assist)
+            event.Skip()
         elif keycode in (ord('1'), ord('2'), ord('5')) and event.ControlDown() and not \
                 event.AltDown():
             self.execute_variable_creator(list_variable=(keycode == ord('2')),
                                           dict_variable=(keycode == ord('5')))
-        # print("DEBUG: Onchar before leaving")
-        # event.Skip() # DEBUG Move up
+        else:
+            event.Skip()
 
     def execute_variable_creator(self, list_variable=False, dict_variable=False):
         from_, to_ = self.GetSelection()
@@ -121,19 +121,8 @@ class _ContentAssistTextCtrlBase(object):
         if self._populate_content_assist():
             self._show_content_assist()
 
-    def _populate_content_assist(self, event=None):
+    def _populate_content_assist(self):
         value = self.GetValue()
-        if event is not None:
-            if event.GetKeyCode() == wx.WXK_BACK:
-                value = value[:-1]
-            elif event.GetKeyCode() == wx.WXK_DELETE:
-                pos = self.GetInsertionPoint()
-                value = value[:pos] + value[pos + 1:]
-            elif event.GetKeyCode() == wx.WXK_ESCAPE:
-                self.hide()
-                return False
-            else:
-                value += unichr(event.GetRawKeyCode())
         (self.gherkin_prefix, value) = self._remove_bdd_prefix(value)
         return self._popup.content_assist_for(value, row=self._row)
 

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -502,7 +502,7 @@ class KeywordEditor(GridEditor, RideEventHandler):
         _iscelleditcontrolshown = self.IsCellEditControlShown()
 
         keycode, control_down = event.GetKeyCode(), event.CmdDown()
-        print("DEBUG: key pressed " + str(keycode) + " + " +  str(control_down))
+        # print("DEBUG: key pressed " + str(keycode) + " + " +  str(control_down))
         # event.Skip()  # DEBUG seen this skip as soon as possible
         if keycode == wx.WXK_CONTROL or \
                 (keycode == ord('M') and (control_down or event.AltDown())):  #  keycode == wx.WXK_CONTROL

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -876,6 +876,7 @@ class ContentAssistCellEditor(GridCellEditor):  # DEBUG wxPhoenix PyGridCellEdi
         self._tc.SetSize((-1, self._height))
         self._tc.set_row(row)
         self._original_value = grid.GetCellValue(row, col)
+        self._tc.SetValue(self._original_value)
         self._grid = grid
         self._tc.SetInsertionPointEnd()
         self._tc.SetFocus()

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -520,8 +520,10 @@ class KeywordEditor(GridEditor, RideEventHandler):
             self.OnSelectAll(event)
         elif event.AltDown() and keycode in [wx.WXK_DOWN, wx.WXK_UP]:
             self._move_rows(keycode)
+            event.Skip()
         elif event.AltDown() and keycode == wx.WXK_RETURN:
             self._move_cursor_down(event)
+            event.Skip()
         elif keycode == wx.WXK_WINDOWS_MENU:
             self.OnCellRightClick(event)
         elif keycode in [wx.WXK_RETURN, wx.WXK_BACK]:
@@ -529,6 +531,7 @@ class KeywordEditor(GridEditor, RideEventHandler):
                 self._move_grid_cursor(event, keycode)
             else:
                 self.save()
+            event.Skip()
         elif (control_down or event.AltDown()) and \
                 keycode == wx.WXK_SPACE:  # Avoid Mac CMD
             self._open_cell_editor_with_content_assist()

--- a/src/robotide/editor/kweditor.py
+++ b/src/robotide/editor/kweditor.py
@@ -502,10 +502,11 @@ class KeywordEditor(GridEditor, RideEventHandler):
         _iscelleditcontrolshown = self.IsCellEditControlShown()
 
         keycode, control_down = event.GetKeyCode(), event.CmdDown()
-        event.Skip()  # DEBUG seen this skip as soon as possible
-        if keycode == ord('M') and \
-            (control_down or event.AltDown()):  #  keycode == wx.WXK_CONTROL
-            self._show_cell_information()
+        print("DEBUG: key pressed " + str(keycode) + " + " +  str(control_down))
+        # event.Skip()  # DEBUG seen this skip as soon as possible
+        if keycode == wx.WXK_CONTROL or \
+                (keycode == ord('M') and (control_down or event.AltDown())):  #  keycode == wx.WXK_CONTROL
+            self.show_cell_information()
         elif keycode == ord('C') and control_down:
             # print("DEBUG: captured Control-C\n")
             self.OnCopy(event)
@@ -545,14 +546,14 @@ class KeywordEditor(GridEditor, RideEventHandler):
         elif control_down and keycode == ord('B'):
             self._navigate_to_matching_user_keyword(
                 self.GetGridCursorRow(), self.GetGridCursorCol())
-        # else:
-        #    event.Skip()
+        else:
+           event.Skip()
 
     def OnGoToDefinition(self, event):
         self._navigate_to_matching_user_keyword(
             self.GetGridCursorRow(), self.GetGridCursorCol())
 
-    def _show_cell_information(self):
+    def show_cell_information(self):
         cell = self.cell_under_cursor
         value = self._cell_value(cell)
         if value:

--- a/src/robotide/editor/popupwindow.py
+++ b/src/robotide/editor/popupwindow.py
@@ -57,8 +57,9 @@ class _PopupWindowBase(object):
         event.Skip()
 
     def show_at(self, position):
-        if not self.IsShown():
+        if self.GetPosition() != position:
             self.SetPosition(position)
+        if not self.IsShown():
             self.Show()
 
     def hide(self, event=None):

--- a/src/robotide/editor/tooltips.py
+++ b/src/robotide/editor/tooltips.py
@@ -27,11 +27,16 @@ class GridToolTips(object):
         self._grid = grid
         self._tooltip_timer = wx.Timer(grid.GetGridWindow())
         grid.GetGridWindow().Bind(wx.EVT_WINDOW_DESTROY, self.OnGridDestroy)
+        grid.GetGridWindow().Bind(wx.EVT_KILL_FOCUS, self.OnGridFocusLost)
         grid.GetGridWindow().Bind(wx.EVT_MOTION, self.OnMouseMotion)
         grid.GetGridWindow().Bind(wx.EVT_TIMER, self.OnShowToolTip)
         grid.Bind(wx.grid.EVT_GRID_EDITOR_HIDDEN, self.OnGridEditorHidden)
 
     def OnGridDestroy(self, event):
+        self._tooltip_timer.Stop()
+        event.Skip()
+
+    def OnGridFocusLost(self, event):
         self._tooltip_timer.Stop()
         event.Skip()
 

--- a/src/robotide/editor/tooltips.py
+++ b/src/robotide/editor/tooltips.py
@@ -42,7 +42,12 @@ class GridToolTips(object):
 
     def OnMouseMotion(self, event):
         self._hide_tooltip()
-        self._start_tooltip_timer()
+        if event.CmdDown():
+            self._tooltip_timer.Stop()
+            self._grid.show_cell_information()
+        else:
+            self._information_popup.hide()
+            self._start_tooltip_timer()
         event.Skip()
 
     def _start_tooltip_timer(self):


### PR DESCRIPTION
some fixes on grid editor:
- content assist when cancelled by ESC return correct value
- when content assist is invoked the existing contents is not cleared
- holding ctrl and hover over keyword show its information (the ctrl + M keyword is also working for backward compatibility )
- tooltips is no longer shown on other tabs
- some idle event crashes fix.